### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project implements a Model Context Protocol (MCP) server that acts as a proxy to the BlazeSQL Natural Language Query API. It allows MCP-compatible clients (like Cursor, Claude 3 with tool use, the MCP Inspector, etc.) to interact with BlazeSQL using natural language.
 
+<a href="https://glama.ai/mcp/servers/@arjshiv/blaze-sql-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@arjshiv/blaze-sql-mcp-server/badge" alt="BlazeSQL Server MCP server" />
+</a>
+
 ## Features
 
 *   Exposes the BlazeSQL Natural Language Query API as an MCP tool named `blazesql_query`.


### PR DESCRIPTION
This PR adds a badge for the [BlazeSQL MCP Server](https://glama.ai/mcp/servers/@arjshiv/blaze-sql-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@arjshiv/blaze-sql-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@arjshiv/blaze-sql-mcp-server/badge" alt="BlazeSQL Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.